### PR TITLE
Add string reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ zip = { version = "0.5", optional = true }
 
 # NOTE: public dependency, so make sure the doc link to Complex in README.md is kept in sync
 num-complex = { version = "0.4", optional = true }
+arrayvec = { version = "0.7.2", optional = true }
 
 [dependencies.npyz-derive]
 path = "derive"
@@ -51,6 +52,7 @@ default = []
 derive = ["npyz-derive"]
 complex = ["num-complex"]
 npz = ["zip"]
+arraystring = ["arrayvec"]
 
 [[bench]]
 name = "bench"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You also may be interested in enabling some features:
 
 ```toml
 [dependencies]
-npyz = {version = "0.6", features = ["derive", "complex", "npz"]}
+npyz = {version = "0.6", features = ["derive", "complex", "npz", "arraystring"]}
 ```
 
 Data can now be read from a `*.npy` file:


### PR DESCRIPTION
When reading a structured array, it's often more convenient to read directly `String` instead of `Vec<u8>`. So I propose to implement `Deserialize` for `String`. 

To implement `Serialize` I propose to use [`ArrayString`](https://docs.rs/arrayvec/0.7.2/arrayvec/struct.ArrayString.html#) in order to carry a max size. As it adds dependency, I add a new optional feature. 

Internally, implementations use `BytesWriter` and `BytesReader`.