### PR TITLE
Export TypeStr fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ Array { a: 2, b: 3.1, c: 5 }
 mod header;
 mod read;
 mod write;
-mod type_str;
+pub mod type_str;
 mod serialize;
 #[cfg(feature = "npz")]
 mod npz_feature;

--- a/src/read.rs
+++ b/src/read.rs
@@ -249,6 +249,11 @@ impl<T: Deserialize, R: io::Read> NpyReader<T, R> {
         &self.reader_and_current_index.0
     }
 
+    /// Get the dtype as written in the file.
+    pub fn dtype(&self) -> DType {
+        self.header.dtype.clone()
+    }
+
     /// Returns the total number of records, including those that have already been read.
     /// (This is the product of [`NpyFile::shape`])
     pub fn total_len(&self) -> u64 {

--- a/src/read.rs
+++ b/src/read.rs
@@ -254,6 +254,11 @@ impl<T: Deserialize, R: io::Read> NpyReader<T, R> {
         self.header.dtype.clone()
     }
 
+    /// Get the shape as written in the file.
+    pub fn shape(&self) -> &[u64] {
+        &self.header.shape
+    }
+
     /// Returns the total number of records, including those that have already been read.
     /// (This is the product of [`NpyFile::shape`])
     pub fn total_len(&self) -> u64 {

--- a/src/type_str.rs
+++ b/src/type_str.rs
@@ -17,15 +17,19 @@ use std::fmt;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TypeStr {
-    pub(crate) endianness: Endianness,
-    pub(crate) type_kind: TypeKind,
-    pub(crate) size: u64,
-    pub(crate) time_units: Option<TimeUnits>,
+    /// Byte order of the data.
+    pub endianness: Endianness,
+    /// Type of the data (integer, float, Python object, etc.).
+    pub type_kind: TypeKind,
+    /// Size of the data (how many bytes is in e.g. the integer).
+    pub size: u64,
+    /// Time units, available when type kind is [`TypeKind::TimeDelta`] or [`TypeKind::DateTime`].
+    pub time_units: Option<TimeUnits>,
 }
 
 /// Represents the first character in a type-string.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum Endianness {
+pub enum Endianness {
     /// Code `<`.
     Little,
     /// Code `>`.
@@ -80,7 +84,7 @@ impl Endianness {
 ///
 /// Indicates the type of data stored.  Affects the interpretation of `size` and `endianness`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum TypeKind {
+pub enum TypeKind {
     /// Code `b`.
     ///
     /// `size` must be 1, and legal values are `0x00` (`false`) or `0x01` (`true`).
@@ -256,7 +260,7 @@ impl TypeStr {
 ///
 /// These appear inside square brackets at the end of the `descr` string for these datatypes.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum TimeUnits {
+pub enum TimeUnits {
     /// Code `Y`.
     Year,
     /// Code `M`.

--- a/src/type_str.rs
+++ b/src/type_str.rs
@@ -1,3 +1,5 @@
+//! An Array Interface type-string.
+
 use std::fmt;
 
 /// Represents an Array Interface type-string.


### PR DESCRIPTION
Sometimes it's useful to access numpy information. In this PR I exported `TypeStr` and relevant field types to users.