### PR TITLE
Expose type str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for the `a` type, which is just an alias of `S`.
 - Added the `arrayvec` feature.  This enables deserialization of
   type `U` without individual allocations per element.
+- Exposed various data from `TypeStr`.  New types include `Endianness`, `TypeChar`,
+  and `TimeUnits` types. `TypeStr` now has getters to extract these fields.
 
 ### Changed
 - `np.datetime64` now uses i64 instead of u64 for serialization, as it is
   defined to use a symmetric interval around the epoch.
+- `DType::num_bytes` has been changed to return `Option<usize>`, rather than panicking when
+  the described datatype is too large to fit in the target platform's `usize` type.
 
 ## [0.6.0] - 2021-07-05
 ### Added

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -11,7 +11,7 @@ macro_rules! gen_benches {
     ($read_to_vec_testname:ident, $write_testname:ident, $T:ty, $new:expr) => {
         #[inline(never)]
         fn write_array_via_push() -> Vec<u8> {
-            let cap = 1000 + <$T>::default_dtype().num_bytes() * NITER;
+            let cap = 1000 + <$T>::default_dtype().num_bytes().unwrap() * NITER;
             let mut cursor = Cursor::new(Vec::with_capacity(cap));
             {
                 let mut writer = npyz::WriteOptions::new().default_dtype().writer(&mut cursor).begin_1d().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,3 +298,4 @@ pub use serialize::FixedSizeBytes;
 pub use serialize::{Serialize, Deserialize, AutoSerialize};
 pub use serialize::{TypeRead, TypeWrite, TypeWriteDyn, TypeReadDyn, DTypeError};
 pub use type_str::{TypeStr, ParseTypeStrError};
+pub use type_str::{Endianness, TypeChar, TimeUnits};

--- a/src/read.rs
+++ b/src/read.rs
@@ -237,7 +237,9 @@ impl<R: io::Read> NpyFile<R> {
         let dtype = DType::from_descr(descr)?;
 
         let n_records = shape.iter().product();
-        let item_size = dtype.num_bytes();
+        let item_size = dtype.num_bytes().ok_or_else(|| {
+            invalid_data(format_args!("dtype is larger than usize!"))
+        })?;
         let strides = strides(order, &shape);
         Ok(NpyHeader { dtype, shape, strides, order, n_records, item_size })
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -251,6 +251,16 @@ impl<T: Deserialize, R: io::Read> NpyReader<T, R> {
         &self.reader_and_current_index.0
     }
 
+    /// Get the dtype as written in the file.
+    pub fn dtype(&self) -> DType {
+        self.header.dtype.clone()
+    }
+
+    /// Get the shape as written in the file.
+    pub fn shape(&self) -> &[u64] {
+        &self.header.shape
+    }
+
     /// Returns the total number of records, including those that have already been read.
     /// (This is the product of [`NpyFile::shape`])
     pub fn total_len(&self) -> u64 {

--- a/src/serialize/primitive.rs
+++ b/src/serialize/primitive.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use num_complex::Complex;
 
 use crate::header::DType;
-use crate::type_str::{TypeStr, Endianness, TypeKind};
+use crate::type_str::{TypeStr, Endianness, TypeChar};
 use super::{DTypeError, TypeRead, TypeWrite, Serialize, Deserialize, AutoSerialize};
 use super::{expect_scalar_dtype};
 
@@ -168,7 +168,7 @@ macro_rules! impl_integer_serializable {
                     //
                     // DateTime is an unsigned integer and TimeDelta is a signed integer,
                     // so we support those too.
-                    &TypeStr { size: $size, endianness, type_kind: $SupportTy, .. } => {
+                    &TypeStr { size: $size, endianness, type_char: $SupportTy, .. } => {
                         Ok(PrimitiveReader::new(endianness))
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("read", type_str)),
@@ -182,7 +182,7 @@ macro_rules! impl_integer_serializable {
             fn writer(dtype: &DType) -> Result<Self::TypeWriter, DTypeError> {
                 match expect_scalar_dtype::<Self>(dtype)? {
                     // Write an integer of the correct size and signedness.
-                    &TypeStr { size: $size, endianness, type_kind: $SupportTy, .. } => {
+                    &TypeStr { size: $size, endianness, type_char: $SupportTy, .. } => {
                         Ok(PrimitiveWriter::new(endianness))
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("write", type_str)),
@@ -199,17 +199,17 @@ macro_rules! impl_integer_serializable {
 }
 
 impl_integer_serializable! {
-    meta: [ (main_ty: TypeKind::Int) (support_ty: TypeKind::Int) ]
+    meta: [ (main_ty: TypeChar::Int) (support_ty: TypeChar::Int) ]
     ints: [ [1 i8] [2 i16] [4 i32] ]
 }
 
 impl_integer_serializable! {
-    meta: [ (main_ty: TypeKind::Int) (support_ty: TypeKind::Int | TypeKind::TimeDelta | TypeKind::DateTime) ]
+    meta: [ (main_ty: TypeChar::Int) (support_ty: TypeChar::Int | TypeChar::TimeDelta | TypeChar::DateTime) ]
     ints: [ [8 i64] ]
 }
 
 impl_integer_serializable! {
-    meta: [ (main_ty: TypeKind::Uint) (support_ty: TypeKind::Uint) ]
+    meta: [ (main_ty: TypeChar::Uint) (support_ty: TypeChar::Uint) ]
     ints: [ [1 u8] [2 u16] [4 u32] [8 u64] ]
 }
 
@@ -222,7 +222,7 @@ macro_rules! impl_float_serializable {
             fn reader(dtype: &DType) -> Result<Self::TypeReader, DTypeError> {
                 match expect_scalar_dtype::<Self>(dtype)? {
                     // Read a float of the correct size
-                    &TypeStr { size: $size, endianness, type_kind: TypeKind::Float, .. } => {
+                    &TypeStr { size: $size, endianness, type_char: TypeChar::Float, .. } => {
                         Ok(PrimitiveReader::new(endianness))
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("read", type_str)),
@@ -236,7 +236,7 @@ macro_rules! impl_float_serializable {
             fn writer(dtype: &DType) -> Result<Self::TypeWriter, DTypeError> {
                 match expect_scalar_dtype::<Self>(dtype)? {
                     // Write a float of the correct size
-                    &TypeStr { size: $size, endianness, type_kind: TypeKind::Float, .. } => {
+                    &TypeStr { size: $size, endianness, type_char: TypeChar::Float, .. } => {
                         Ok(PrimitiveWriter::new(endianness))
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("write", type_str)),
@@ -246,7 +246,7 @@ macro_rules! impl_float_serializable {
 
         impl AutoSerialize for $float {
             fn default_dtype() -> DType {
-                DType::new_scalar(TypeStr::with_auto_endianness(TypeKind::Float, $size, None))
+                DType::new_scalar(TypeStr::with_auto_endianness(TypeChar::Float, $size, None))
             }
         }
 
@@ -259,7 +259,7 @@ macro_rules! impl_float_serializable {
                 const SIZE: u64 = 2 * $size;
 
                 match expect_scalar_dtype::<Self>(dtype)? {
-                    &TypeStr { size: SIZE, endianness, type_kind: TypeKind::Complex, .. } => {
+                    &TypeStr { size: SIZE, endianness, type_char: TypeChar::Complex, .. } => {
                         Ok(ComplexReader { float: PrimitiveReader::new(endianness) })
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("read", type_str)),
@@ -276,7 +276,7 @@ macro_rules! impl_float_serializable {
                 const SIZE: u64 = 2 * $size;
 
                 match expect_scalar_dtype::<Self>(dtype)? {
-                    &TypeStr { size: SIZE, endianness, type_kind: TypeKind::Complex, .. } => {
+                    &TypeStr { size: SIZE, endianness, type_char: TypeChar::Complex, .. } => {
                         Ok(ComplexWriter { float: PrimitiveWriter::new(endianness) })
                     },
                     type_str => Err(DTypeError::bad_scalar::<Self>("write", type_str)),
@@ -288,7 +288,7 @@ macro_rules! impl_float_serializable {
         /// _This impl is only available with the **`"complex"`** feature._
         impl AutoSerialize for Complex<$float> {
             fn default_dtype() -> DType {
-                DType::new_scalar(TypeStr::with_auto_endianness(TypeKind::Complex, $size, None))
+                DType::new_scalar(TypeStr::with_auto_endianness(TypeChar::Complex, $size, None))
             }
         }
     )+};

--- a/src/type_matchup_docs.rs
+++ b/src/type_matchup_docs.rs
@@ -34,6 +34,10 @@ When the **`"complex"`** feature is enabled, rust types [`Complex32`] and [`Comp
 
 **Notice:** numpy does have have complex numbers backed by 128-bit floats, but this is not supported by `npyz`.
 
+### Bool
+
+The rust type `bool` may be serialized as `|b1`.
+
 ### Endianness
 
 In all of the above cases, npyz uses the machine endianness by default when serializing, but

--- a/src/type_str.rs
+++ b/src/type_str.rs
@@ -14,7 +14,7 @@ use std::fmt;
 ///
 /// assert_eq!(format!("{}", ts), "|i1");
 /// assert_eq!(ts.endianness(), npyz::Endianness::Irrelevant);
-/// assert_eq!(ts.type_char(), npyz::Endianness::Int);
+/// assert_eq!(ts.type_char(), npyz::TypeChar::Int);
 /// assert_eq!(ts.size_field(), 1);
 /// # Ok(())
 /// # }


### PR DESCRIPTION
Implements the changes [described here](https://github.com/ExpHP/npyz/pull/48#issuecomment-1207437892).  (except for the builder; that can be backwards compatibly added later)

3 types didn't seem like enough to warrant their own module, so I export them from the root.

When exposing `num_bytes()` on TypeStr, it occurred to me that there is the potential for overflow on malicious inputs.  I updated the type to `Option<usize>`, and likewise on DType.