### PR TITLE
Flush writer when `finish` is called

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -442,6 +442,7 @@ impl<Row: Serialize + ?Sized , W: Write> NpyWriter<Row, W> {
                 self.fw.seek(SeekFrom::Start(end_pos))?;
             },
         }
+        self.fw.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
Hi,

I encountered an issue where the writer did not flush when dropped resulting in incomplete npy files. Flushing in finish resolves the issue.