### PR TITLE
Use `py_literal` for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ members = [ "derive" ]
 
 [dependencies]
 byteorder = "1"
-nom = "3"
-zip = { version = "0.5", optional = true }  # NOTICE: also in dev-dependencies
+py_literal = "0.4"
+zip = { version = "0.6", optional = true }  # NOTICE: also in dev-dependencies
 
 # NOTE: public dependencies, so make sure the doc links in lib.rs are kept in sync
 num-complex = { version = "0.4", optional = true }
@@ -41,10 +41,10 @@ default-features = false
 # breaking semver bumps very frequently.
 #
 # Also, sprs has an ndarray dependency that might not be the most recent.
-ndarray = { version = "0.14" }
-sprs = { version = "0.10", default-features = false }
+ndarray = { version = "0.15" }
+sprs = { version = "0.11", default-features = false }
 bencher = { version = "0.1" }
-zip = { version = "0.5" }  # NOTICE: also in dependencies
+zip = { version = "0.6" }  # NOTICE: also in dependencies
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [ "derive" ]
 byteorder = "1"
 py_literal = "0.4"
 zip = { version = "0.6", optional = true }  # NOTICE: also in dev-dependencies
+num-bigint = "0.4"
 
 # NOTE: public dependencies, so make sure the doc links in lib.rs are kept in sync
 num-complex = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ No features are enabled by default.  Here is the list of existing features:
   * **`"arrayvec"`** enables the use of [`arrayvec::ArrayVec`] and [`arrayvec::ArrayString`]
     as alternatives to `Vec` and `String` for some string types.
 * **`"derive"`** enables derives of traits for working with structured arrays.
-  This will add a build-time dependency on common proc macro utilities (`syn`, `quote`).
 * **`"npz"`** enables adapters for working with NPZ files
   (including scipy sparse matrices),
   adding a public dependency on the `zip` crate.


### PR DESCRIPTION
Uses [`py_literal`](https://crates.io/crates/py_literal) for parsing, removing the dependency on nom 3. Fixes #56.