### PR TITLE
Make `NpyHeader` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes since the latest release!
+### Added
+- `NpyHeader` is now `pub`.
 
 ## [0.7.4] - 2023-02-01
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ pub use zip;
 
 pub use header::{DType, Field};
 #[allow(deprecated)]
-pub use read::{NpyData, NpyFile, NpyReader, Order};
+pub use read::{NpyData, NpyFile, NpyHeader, NpyReader, Order};
 #[allow(deprecated)]
 pub use write::{to_file, to_file_1d, OutFile, NpyWriter, write_options, WriteOptions, WriterBuilder};
 pub use serialize::FixedSizeBytes;


### PR DESCRIPTION
Closes #63.
I made all fields public since it's just an object that you create from a reader. In `NpyFile` it stays private, so it's impossible to mess with fields after reading.

I would also suggest to replace getters for header from `NpyFile` and `NpyReader` with a single getter that just returns their header by reference. Just to reduce the amount of boilerplate.