### PR TITLE
added npz support for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ num-bigint = "0.4"
 # NOTE: public dependencies, so make sure the doc links in lib.rs are kept in sync
 num-complex = { version = "0.4", optional = true }
 arrayvec = { version = "0.7.2", optional = true }
-half = { version = "2.3.1", optional = true }
+half = { version = ">=2.1.0", optional = true }
 
 
 [dependencies.npyz-derive]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ num-bigint = "0.4"
 num-complex = { version = "0.4", optional = true }
 arrayvec = { version = "0.7.2", optional = true }
 half = { version = "2.3.1", optional = true }
-zip = { version = "0.6", optional = true } # NOTICE: also in dev-dependencies
 
 
 [dependencies.npyz-derive]
@@ -38,6 +37,12 @@ path = "derive"
 version = "0.7.0"
 optional = true
 default-features = false
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+zip = { version = "0.6",optional = true}
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+zip = { version = "0.6", default-features = false,features = ["deflate"],optional = true}
 
 [dev-dependencies]
 # For examples ONLY.  We don't want to provide a public interface because ndarray undergoes
@@ -49,9 +54,10 @@ sprs = { version = "0.11", default-features = false }
 bencher = { version = "0.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-zip = { version = "0.6" }  # NOTICE: also in dependencies
+zip = { version = "0.6", default-features = true }  # NOTICE: also in dependencies
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+zip = { version = "0.6", default-features = false,features = ["deflate"]}
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 

--- a/run_wasm_tests.sh
+++ b/run_wasm_tests.sh
@@ -5,4 +5,5 @@ set -x
 
 wasm-pack test --node --test nd
 wasm-pack test --node --test roundtrip --features derive --features half
+wasm-pack test --node --test npz --features derive --features npz
 wasm-pack test --node --test serialize_array --features derive

--- a/tests/npz.rs
+++ b/tests/npz.rs
@@ -2,13 +2,18 @@ use std::io;
 use npyz::WriterBuilder;
 use npyz::npz::{NpzArchive, NpzWriter};
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
 #[test]
 fn read_uncompressed() {
-    test_basic_read(NpzArchive::open("test-data/uncompressed.npz").unwrap())
+    let mut data = io::Cursor::new(include_bytes!("../test-data/uncompressed.npz").to_vec());
+    test_basic_read(NpzArchive::new(&mut data).unwrap())
 }
 #[test]
 fn read_compressed() {
-    test_basic_read(NpzArchive::open("test-data/compressed.npz").unwrap())
+    let mut data = io::Cursor::new(include_bytes!("../test-data/compressed.npz").to_vec());
+    test_basic_read(NpzArchive::new(&mut data).unwrap())
 }
 
 // Python code to create NPZs:


### PR DESCRIPTION
Hey,
Currently, NPZ (zip) files are not supported for wasm.
The zip crate uses bzip2 by default, which does not support wasm.
By switching to deflate, we can support NPZ files for wasm (https://github.com/zip-rs/zip/issues/113).

I changed the dependencies accordingly and added some tests.
I also tested it in the browser.

Best
Simon