### PR TITLE
Fast reading for primitive types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ num-bigint = "0.4"
 num-complex = { version = "0.4", optional = true }
 arrayvec = { version = "0.7.2", optional = true }
 half = { version = "2.1.0", optional = true }
-
+bytemuck = {version = "1.15.0", optional = true}
 
 [dependencies.npyz-derive]
 path = "derive"
@@ -70,6 +70,7 @@ arrayvec = ["dep:arrayvec"]
 complex = ["dep:num-complex"]
 half = ["dep:half"]
 npz = ["dep:zip"]
+bytemuck= ["dep:bytemuck"]
 
 [[bench]]
 name = "bench"

--- a/src/read.rs
+++ b/src/read.rs
@@ -182,7 +182,7 @@ pub struct NpyReader<T: Deserialize, R: io::Read> {
     header: NpyHeader,
     type_reader: <T as Deserialize>::TypeReader,
     // stateful parts, put together like this to remind you to always update them in sync
-    reader_and_current_index: (R, u64),
+    pub reader_and_current_index: (R, u64),
 }
 
 /// Legacy type for reading `npy` files.
@@ -346,7 +346,7 @@ impl NpyHeader {
 
 impl<T: Deserialize, R: io::Read> NpyReader<T, R> {
     #[inline(always)]
-    pub fn reader(&self) -> &R {
+    fn reader(&self) -> &R {
         &self.reader_and_current_index.0
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -429,20 +429,21 @@ impl<R: io::Read, T: Deserialize + bytemuck::Pod> NpyReader<T, R> {
     pub fn read_complete(&mut self) -> io::Result<Vec<T>> {
         match &self.header.dtype{
             DType::Plain(d) =>{
-                if cfg!(endian = "big") {
+                #[cfg(target_endian = "big")]
+                {
                     if d.endianness == Endianness::Big{
                         self.read_bytemuck()
                     }else{
                         self.read_byteorder()
                     }
-                }else if cfg!(endian = "big") {
+                }
+                #[cfg(target_endian = "little")]
+                {
                     if d.endianness == Endianness::Little{
                         self.read_bytemuck()
                     }else{
                         self.read_byteorder()
                     }
-                }else{
-                    panic!("unsuporrted endianess {:}" ,cfg!(endian))
                 }
             },
             _ => io::Result::Err(io::Error::new(io::ErrorKind::InvalidData, "only supported for plain data types"))

--- a/src/read.rs
+++ b/src/read.rs
@@ -346,7 +346,7 @@ impl NpyHeader {
 
 impl<T: Deserialize, R: io::Read> NpyReader<T, R> {
     #[inline(always)]
-    fn reader(&self) -> &R {
+    pub fn reader(&self) -> &R {
         &self.reader_and_current_index.0
     }
 

--- a/src/serialize/primitive.rs
+++ b/src/serialize/primitive.rs
@@ -18,6 +18,14 @@ pub trait PrimitiveReadWrite: Sized {
     #[doc(hidden)]
     fn primitive_read_one<R: io::Read>(reader: R, swap_bytes: bool) -> io::Result<Self>;
     #[doc(hidden)]
+    fn primitive_read_many<R:io::Read>(mut reader: R, swap_bytes: bool,n:usize) -> io::Result<Vec<Self>> {
+        let mut vec = Vec::with_capacity(n);
+        for _ in 0..n {
+            vec.push(Self::primitive_read_one(&mut reader, swap_bytes)?);
+        }
+        Ok(vec)
+    }
+    #[doc(hidden)]
     fn primitive_write_one<W: io::Write>(&self, writer: W, swap_bytes: bool) -> io::Result<()>;
 }
 
@@ -35,6 +43,24 @@ macro_rules! derive_int_primitive_read_write {
                 match swap_bytes {
                     true => Ok(out.swap_bytes()),
                     false => Ok(out),
+                }
+            }
+
+            #[inline]
+            fn primitive_read_many<R:io::Read>(mut reader: R, swap_bytes: bool,n:usize) -> io::Result<Vec<$int>> {
+                if !swap_bytes{
+                    use std::mem::size_of;
+
+                    let mut buf:Vec<u8> = vec![0u8; size_of::<$int>()*n];
+                    reader.read_exact(&mut buf)?;
+    
+                   Ok(bytemuck::cast_slice(&buf).to_vec())
+                }else{
+                    let mut vec = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        vec.push(Self::primitive_read_one(&mut reader, swap_bytes)?);
+                    }
+                    Ok(vec)
                 }
             }
 
@@ -61,6 +87,25 @@ macro_rules! derive_float_primitive_read_write {
                 let bits = <$int>::primitive_read_one(reader, swap_bytes)?;
                 Ok(<$float>::from_bits(bits))
             }
+
+            #[inline]
+            fn primitive_read_many<R:io::Read>(mut reader: R, swap_bytes: bool,n:usize) -> io::Result<Vec<$float>> {
+                if !swap_bytes{
+                    use std::mem::size_of;
+
+                    let mut buf:Vec<u8> = vec![0u8; size_of::<$int>()*n];
+                    reader.read_exact(&mut buf)?;
+    
+                   Ok(bytemuck::cast_slice(&buf).to_vec())
+                }else{
+                    let mut vec = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        vec.push(Self::primitive_read_one(&mut reader, swap_bytes)?);
+                    }
+                    Ok(vec)
+                }
+            }
+
 
             #[inline]
             fn primitive_write_one<W: io::Write>(&self, writer: W, swap_bytes: bool) -> io::Result<()> {
@@ -131,6 +176,11 @@ impl<T: PrimitiveReadWrite> TypeRead for PrimitiveReader<T> {
     fn read_one<R: io::Read>(&self, reader: R) -> io::Result<Self::Value> {
         T::primitive_read_one(reader, self.swap_bytes)
     }
+    
+    fn read_many<R: io::Read>(&self, mut bytes: R,n:usize) -> io::Result<Vec<Self::Value>> {
+        T::primitive_read_many(&mut bytes, self.swap_bytes,n)
+    }
+    
 }
 
 impl<T: PrimitiveReadWrite> TypeWrite for PrimitiveWriter<T> {


### PR DESCRIPTION
Hello,

I often want to read the whole data from an array (using `.into_vec()`).
I have noticed that this is considerably slower for large arrays compared to numpy.

Numpy:
![Screenshot from 2024-05-16 16-34-23](https://github.com/ExpHP/npyz/assets/14186588/8df89c78-2910-46c5-a85a-78a7bdec76fd)

This crates takes 6 times as long just for reading:
```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let file = File::open("big.npy")?;

    let npy = npyz::NpyFile::new(file)?;
    let mut sum:f32 = 0.;
    let start = std::time::Instant::now();
    let data = npy.into_vec::<f32>()?;

    println!("reading took: {:?}", start.elapsed());
    
    // do something
    println!("length {:?}", data.len()  );
    

    for arr in data {
        sum+=arr;
    }
    println!("{:.4}", sum);
    Ok(())
}

```

output:
![Screenshot from 2024-05-16 16-33-32](https://github.com/ExpHP/npyz/assets/14186588/2227c262-d8e5-4504-a0ad-b2ca5da289e4)


This boils down to the reader reading and parsing every primitive one by one.
In many cases, we can copy the data into memory and reinterpret it (this is also what Numpy does).

I added a fast read functionality for primitive types using the `bytemuck` crate.  
This makes it about 10 times faster:
![Screenshot from 2024-05-16 16-33-47](https://github.com/ExpHP/npyz/assets/14186588/558cb289-0033-468a-a1c9-afc367332983)

What are your thoughts about this? 
My solution adds minimal code and only speeds up the reads for the primitives where it is safe. 

Sorry for the convoluted git history...please squash it on merge in GitHub.

Best
Simon